### PR TITLE
[BOJ, SEA] 이정복/ 2주차

### DIFF
--- a/Java/이정복/[Week 2]자료구조 2/[BOJ] 과제_13904_골드3.java
+++ b/Java/이정복/[Week 2]자료구조 2/[BOJ] 과제_13904_골드3.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        // 입력받기
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int length = Integer.parseInt(br.readLine());
+
+        // 날짜별로 map에 넣기 (마감일 - 점수배열)
+        TreeMap<Integer, ArrayList<Integer>> map = new TreeMap<>();
+        for(int i=0; i<length; i++){
+            String[] tempText = br.readLine().split(" ");
+            int[] tempints = {Integer.parseInt(tempText[0]), Integer.parseInt(tempText[1])};
+            int key = tempints[0];
+            int value = tempints[1];
+
+            if(map.containsKey(tempints[0])){
+                List<Integer> values = map.get(key);
+                values.add(value);
+            } else {
+                map.put(key, new ArrayList<Integer>());
+                map.get(key).add(value);
+            }
+        }
+
+        // 마감일이 늦는 것부터 확인
+        int Lastday = map.lastKey();
+        int sum = 0;
+
+        for(int today=Lastday; today>0; today--){
+            // 최대값과 해당 값을 갖는 키값
+            int now = 0;
+            int index = -1;
+
+            // 남은 과제 중에서 점수 최대값 선택 후 삭제
+            for(int i = today; i<=Lastday; i++){
+                if(map.containsKey(i)) {
+                    ArrayList<Integer> list = map.get(i);
+                    for (int score : list) {
+                        if (score > now) {
+                            now = score;
+                            index = i;
+                        }
+                    }
+                }
+            }
+            if(index != -1) {
+                map.get(index).remove(map.get(index).indexOf(now));
+                sum += now;
+                if (map.get(index).isEmpty()) {
+                    map.remove(index);
+                }
+            }
+        }
+        System.out.println(sum);
+    }
+}

--- a/Java/이정복/[Week 2]자료구조 2/[BOJ] 단어 공부_1157_브론즈1.java
+++ b/Java/이정복/[Week 2]자료구조 2/[BOJ] 단어 공부_1157_브론즈1.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        // 입력을 받고, 단어에 들어간 글자와 빈도를 저장할 맵에 저장
+        TreeMap<Character, Integer> map = new TreeMap<>();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String Text = br.readLine().toUpperCase();
+
+        for(int i = 0; i < Text.length(); i++) {
+            char now = Text.charAt(i);
+
+            if(map.get(now) != null){
+                map.replace(now, map.get(now)+1);
+            }
+            else {
+                map.put(now, 1);
+            }
+        }
+
+        int max = 0;
+        char result = '?';
+        
+        // 최대값을 갖는 키를 찾고, 키가 여러개라면 ? 출력
+        for (Map.Entry<Character, Integer> entry : map.entrySet()) {
+            int now = entry.getValue();
+            if (now > max) {
+                max = now;
+                result = entry.getKey();
+            }
+            else if (now == max) {
+                result = '?';
+            }
+        }
+        System.out.println(result);
+    }
+}

--- a/Java/이정복/[Week 2]자료구조 2/[SEA] 스도쿠 검증_D2.java
+++ b/Java/이정복/[Week 2]자료구조 2/[SEA] 스도쿠 검증_D2.java
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Solution {
+    public static void main(String[] args) throws IOException {
+        // Scanner보다 실행 시간이 빠른 BufferedReader 사용
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String Text = br.readLine();
+
+        // 스도쿠 개수 입력받고 배열 생성
+        int length = Integer.parseInt(Text);
+        for(int freq_case = 0; freq_case<length; freq_case++) {
+            //스도쿠 입력받기
+            int[][] array = new int[9][9];
+            for (int i = 0; i < 9; i++) {
+                String[] Tokens = br.readLine().split(" ");
+                for (int j = 0; j < 9; j++) {
+                    array[i][j] = Integer.parseInt(Tokens[j]);
+                }
+            }
+            
+            // set.contains() 함수를 이용해 중복을 검사 후 중복이 있다면 0 출력
+            int complete = 1;
+            // 가로 검사
+            for (int i = 0; i < 9; i++) {
+                HashSet<Integer> set = new HashSet<>();
+                for (int j = 0; j < 9; j++) {
+                    if (set.contains(array[i][j])) {
+                        complete = 0;
+                    }
+                    set.add(array[i][j]);
+                }
+            }
+
+            // 세로 검사
+            for (int i = 0; i < 9; i++) {
+                HashSet<Integer> set = new HashSet<>();
+                for (int j = 0; j < 9; j++) {
+                    if (set.contains(array[j][i])) {
+                        complete = 0;
+                    }
+                    set.add(array[j][i]);
+                }
+            }
+
+            // 9x9 검사
+            for (int i = 0; i < 9; i += 3) {
+                for (int j = 0; j < 9; j += 3) {
+                    HashSet<Integer> set = new HashSet<>();
+
+                    //아래 for문은 최대 수행 횟수가 9회이기 때문에 O(n)으로 취급
+                    for (int k = 0; k < 3; k++) {
+                        for (int s = 0; s < 3; s++) {
+                            if (set.contains(array[i + k][j + s])) {
+                                complete = 0;
+                            }
+                            set.add(array[i + k][j + s]);
+                        }
+                    }
+                }
+            }
+
+            System.out.printf("#%d %d\n", freq_case+1, complete);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 단어공부
-   플랫폼: BOJ

## 💡 아이디어 & 접근 방식

- 단어를 구성하는 글자별로 빈도수를 카운트 (**map**에 key값으로 글자를, value값으로 빈도수 저장)
- 단어 입력이 끝났다면 모든 key값을 방문하며 빈도수가 가장 많은 글자를 탐색
- 탐색 중 최대 빈도수를 갖는 글자가 또 나왔다면 ? 출력

이 문제에 맞는 자료구조가 뭘까 고민하다가 map을 쓰면 글자를 키값으로 해서 value값을 관리하기 편하겠다 싶어서 map을 사용하는 방식으로 풀어봤습니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 목표 시간 이내 해결

## 📝 특이사항
자바에서 for (int a : List) 형식의 반복문을 처음 사용해본 문제.
인덱스가 필요없는 반복 시 쓰기 좋을 것 같습니다.

-----------
## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 스도쿠 검증
-   플랫폼: SEA

## 💡 아이디어 & 접근 방식

- 스도쿠 내용을 2차원 배열에 저장
- set에 가로, 세로, 3x3상자 형식으로 넣어가며 중복이 있는지 확인
- 중복이 하나라도 있다면 0을 출력

중복을 검사해야 하기 때문에 키값의 중복을 허용하지 않는 set을 사용하는 것이 좋겠다는 생각으로 set을 사용했습니다.
add()함수를 if문에 넣어서 코드를 줄일 수 있었을 것 같습니다. (중복된 값을 넣으려고 할 시 false를 반환함)

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 목표 시간 이내 해결

## 📝 특이사항


-------------
## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 과제 
-   플랫폼: BOJ

## 💡 아이디어 & 접근 방식

- 마감일, 점수 형식으로 전달되는 데이터를 <Integer, ArrayList<Integer>> 형식의 map에 저장 (마감일, {점수 배열} 형식)
- 가장 마지막 마감일부터 해결할 수 있는 과제 중 가장 높은 점수를 갖는 문제를 선택 (Greedy)
- 선택된 문제는 ArrayList에서 삭제하고, ArrayList가 비었다면 해당 키값과 배열을 map에서 삭제

처음 문제를 봤을 때 greedy하게 풀면 되겠다 싶었는데, 마감일에 맞춰서 값을 조회하는 것이 어려웠습니다.
마감일을 key값으로 써서 점수들을 배열로 관리하면 편하겠다 싶어서 이 방식으로 풀어봤습니다.
map의 value값으로 들어가있는 배열을 관리하는 방법을 찾아보느라 시간이 오래걸렸습니다.(Java 공식문서 활용)
 

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 목표 시간 이내 해결

## 📝 특이사항
