### PR TITLE
[BOJ/PGS] 6/7주차 양채연

### DIFF
--- a/Java/양채연/[Week 6]수학_백트래킹/[BOJ]에라토스테네스의 체_2960_실버4.java
+++ b/Java/양채연/[Week 6]수학_백트래킹/[BOJ]에라토스테네스의 체_2960_실버4.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        ArrayList<Integer> arr = new ArrayList<>();
+        int lastNum = 0;
+
+        for (int i = 2; i <= N; i++) {
+            arr.add(i);
+        }
+
+        while(K>0){
+            int p = arr.get(0);
+            lastNum = arr.get(0);
+            arr.remove(0);
+            K--;
+            if (K == 0) break;
+
+            for(int i= 0 ; i<arr.size();i++){
+                if(arr.get(i)%p==0) {
+                    lastNum = arr.get(i);
+                    arr.remove(i);
+                    K--;
+                    i--;
+                    if (K == 0) break;
+                }
+            }
+        }
+        System.out.println(lastNum);
+
+    }
+}

--- a/Java/양채연/[Week 6]수학_백트래킹/{BOJ]더하기 사이클_1110_브론즈1.java
+++ b/Java/양채연/[Week 6]수학_백트래킹/{BOJ]더하기 사이클_1110_브론즈1.java
@@ -1,0 +1,26 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int firstNum = n;
+        int newNum = 0;
+        int cycle = 0;
+
+
+        while (true) {
+            newNum = (n % 10) * 10 + (n / 10 + n % 10) % 10;
+            cycle++;
+
+            if (firstNum == newNum) break;
+            n = newNum;
+        }
+
+        System.out.println(cycle);
+
+
+    }
+}

--- a/Java/양채연/[Week 7]그리디/[BOJ]거스름 돈_14916_실버5_java
+++ b/Java/양채연/[Week 7]그리디/[BOJ]거스름 돈_14916_실버5_java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int cnt = 0;
+
+
+        switch (n % 5) {
+            case 0:
+                cnt += n / 5;
+                break;
+            case 1:
+                if (n < 5) {
+                    cnt = -1;
+                    break;
+                } else {
+                    cnt += n / 5 - 1 + 3;
+                    break;
+                }
+
+            case 2:
+                cnt += n / 5 + 1;
+                break;
+            case 3:
+                if (n < 5) {
+                    cnt = -1;
+                    break;
+                } else {
+                    cnt += n / 5 - 1 + 4;
+                    break;
+                }
+            case 4:
+                cnt += n / 5 + 2;
+                break;
+        }
+        System.out.println(cnt);
+    }
+
+}

--- a/Java/양채연/[Week 7]그리디/[BOJ]문서 검색_1543_실버5,java
+++ b/Java/양채연/[Week 7]그리디/[BOJ]문서 검색_1543_실버5,java
@@ -1,0 +1,22 @@
+import javax.sound.midi.Soundbank;
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String docs = br.readLine();
+        String search = br.readLine();
+        int cnt = 0;
+        int idx = 0;
+
+
+        while ((idx = docs.indexOf(search, idx)) != -1) {
+            cnt++;
+            idx += search.length();
+        }
+        System.out.println(cnt);
+    }
+
+}

--- a/Java/양채연/[Week 7]그리디/[BOJ]카약과 강풍_2891_실버4.java
+++ b/Java/양채연/[Week 7]그리디/[BOJ]카약과 강풍_2891_실버4.java
@@ -1,0 +1,49 @@
+import javax.sound.midi.Soundbank;
+import java.io.*;
+import java.lang.reflect.Array;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int n = Integer.parseInt(st.nextToken());
+        int s = Integer.parseInt(st.nextToken());
+        int r = Integer.parseInt(st.nextToken());
+        int[] kayak = new int[n + 1];
+        int cnt=0;
+//        Arrays.fill(kayak, 1);
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < s; i++) {
+            int tmp = Integer.parseInt(st.nextToken());
+            kayak[tmp]--;
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < r; i++) {
+            int tmp = Integer.parseInt(st.nextToken());
+            kayak[tmp]++;
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (kayak[i] == -1) {
+                if (i > 1 && kayak[i - 1] == 1) {
+                    kayak[i - 1]--;
+                    kayak[i]++;
+                } else if (i<n && kayak[i + 1] == 1) {
+                    kayak[i + 1]--;
+                    kayak[i]++;
+                }
+            }
+        }
+        for (int i = 1; i <= n; i++) {
+            if(kayak[i]==-1)
+                cnt++;
+        }
+        System.out.println(cnt);
+
+    }
+
+}

--- a/Java/양채연/[Week 7]그리디/[PGS]체육복_Lv.1.java
+++ b/Java/양채연/[Week 7]그리디/[PGS]체육복_Lv.1.java
@@ -1,0 +1,31 @@
+class Solution {
+    public int solution(int n, int[] lost, int[] reserve) {
+        int answer = n;
+        int[] arr = new int[n+1];
+
+        for(int i = 1 ; i <=reserve.length-1;i ++){
+            arr[reserve[i]]++;
+        }
+        for(int i = 1; i <=lost.length-1;i++){
+            arr[lost[i]]--;
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (arr[i] == -1) {
+                if (i > 1 && arr[i - 1] == 1) {
+                    arr[i - 1]--;
+                    arr[i]++;
+                } else if (i<n && arr[i + 1] == 1) {
+                    arr[i + 1]--;
+                    arr[i]++;
+                }
+            }
+        }
+
+        for(int i = 1; i <= n;i ++){
+            if(arr[i]==-1)
+                answer--;
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 📌 [BOJ/PGS] 6/7주차 양채연

## ✅ 문제 설명 (1/6)

-   문제 이름: 더하기 사이클
-   플랫폼: 백준

## 💡 아이디어 & 접근 방식
(n % 10) * 10 + (n / 10 + n % 10) % 10
처음 값과 현재 값이 같을 때 까지 위의 식을 while문으로 반복했습니다

## ✅ 해결 여부 (1/6)

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 목표 시간 이내 해결

## 📝 특이사항
x


## ✅ 문제 설명 (2/6)

-   문제 이름: 에라토스테네스의 체
-   플랫폼: 백준

## 💡 아이디어 & 접근 방식
ArraryList에 값을 저장하고 for문으로 전체를 돌면서 맨 앞에 저장된 값으로 나누어 떨어지면 remove하기를 반복했습니다
-

## ✅ 해결 여부 (2/6)

-   [x] 예제 입력/출력 통과 
-   [x] 모든 테스트 케이스 통과
-   [x] 목표 시간 이내 해결

## 📝 특이사항
x

## ✅ 문제 설명 (3/6)

-   문제 이름: 거스름돈
-   플랫폼: 백준

## 💡 아이디어 & 접근 방식
동전이 2원 5원으로만 구성되어있기 때문에 우선 5로 최대한 거슬러 주었습니다
남은 금액이 2로 나누어 떨어지지 않으면 1개의 5원만 회수하고 2원으로 거슬러주었습니다
switch case를 활용하였습니다

## ✅ 해결 여부 (3/6)

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 목표 시간 이내 해결

## 📝 특이사항
이번 거스름 돈 문제는 그리디 문제였지만 일반적으로는 DP를 사용해야 하는 문제들이 주를 이룬다고 합니다!

## ✅ 문제 설명 (4/6)

-   문제 이름: 문서 검색
-   플랫폼: 백준

## 💡 아이디어 & 접근 방식
우선 String에 문자열을 저장하고, 검색 키워드를 contains로 찾아서 공백으로 변환하며 동시에 횟수를 카운트하는 방식으로 접근했습니다. 그런데 통과가 안돼서 어떤 문제가 있을까 찾아보았습니다! 예를 들어 aabcbc에서 abc를 검색하는 케이스가 있다면 답은 1이 나와야 합니다. 하지만 위의 방식으로 풀었을 경우 abc가 삭제됨과 함께 앞의 문자열과 뒤의 문자열이 abc로 연결이 되고, 이후에 abc가 한 번 더 검색되는 문제가 있었습니다. 그래서 indexof를 활용하여 검색하는 방식으로 변경하였습니다!

## ✅ 해결 여부 (4/6)

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 목표 시간 이내 해결

## 📝 특이사항 
X

## ✅ 문제 설명 (5/6)

-   문제 이름: 체육복
-   플랫폼: 프로그래머스

## 💡 아이디어 & 접근 방식
아래의 카약과 강풍과 같은 문제라 알고리즘은 빠르게 작성했지만 오류가 났고 해결하지 못했습니다,,

## ✅ 해결 여부 (5/6)

-   [x] 예제 입력/출력 통과
-   [ ] 모든 테스트 케이스 통과
-   [ ] 목표 시간 이내 해결

## 📝 특이사항
스터디 시간 중 원희님이 잘못된 부분 찾아주셨습니다~~
(lost와 reserve 배열을 index 0부터 탐색해야하는데 1부터 탐색함)


## ✅ 문제 설명 (6/6)

-   문제 이름: 카약과 강풍
-   플랫폼: 백준

## 💡 아이디어 & 접근 방식
우선 카약의 개수를 파악할 수 있는 배열을 하나 생성하고 전체를 for문으로 돌면서 카약이 없을 경우 앞,뒤 인덱스를 확인해서 카약 개수를 변경했습니다

## ✅ 해결 여부 (6/6)
-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 목표 시간 이내 해결

## 📝 특이사항 
X